### PR TITLE
Create service, task definition, default security group, attach role policies and XRay container and optionally set Auto scaling policies

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.89.0"
+  constraints = ">= 4.9.0"
+  hashes = [
+    "h1:rFvk42jJEKiSUhK1cbERfNgYm4mD+8tq0ZcxCwpXSJs=",
+    "zh:0e55784d6effc33b9098ffab7fb77a242e0223a59cdcf964caa0be94d14684af",
+    "zh:23c64f3eaeffcafb007c89db3dfca94c8adf06b120af55abddaca55a6c6c924c",
+    "zh:338f620133cb607ce980f1725a0a78f61cbd42f4c601808ec1ee01a6c16c9811",
+    "zh:6ab0499172f17484d7b39924cf06782789df1473d31ebae0c7f3294f6e7a1227",
+    "zh:6dcde3e29e538cdf80971cbdce3b285056fd0e31dd64b02d2dcdf4c02f21d0a9",
+    "zh:75c9b594d77c9125bfb1aaf3fbd77a49e392841d53029b5726eb71d64de1233e",
+    "zh:7b334c23091e7b4c142e378416586292197c40a31a5bdb3b29c4f9afddd286f0",
+    "zh:991bbba72e5eb6eb351f466d68080992f5b0495f862a6723f386d1b4c965aa7d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9bd2f12eef4a5dceafc211ab3b9a63f0e3e224007a60c1bbb842f76e0377033d",
+    "zh:b1ac1eb3b3e1a79fa5e5ad3364615f23b9ee0b093ceeb809fd386a4d40e7abb4",
+    "zh:cea91f43151b30c428c441b97c3b98bf1e5fb72ef72f6971308e3895e23437f4",
+    "zh:d3f000a1696a43d8186a516aace7d476d1fd76443627980504133477e19c8ecb",
+    "zh:d6f526fbbb3e51b3acc3b9640a158f7acc4a089632fca8ec6db430b450673f25",
+    "zh:e0c542950f96c93e761d50602e449fef8447f1389a6d5242a0a7dc9b06826d0b",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.5.2"
+  constraints = ">= 1.2.0"
+  hashes = [
+    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,109 @@
 # terraform-aws-ecs-service
 Create a ECS (fargate) service following Luscii standards
 
+## Examples
+
+### With Load Balancer
+```terraform
+module "lb_service" {
+
+}
+```
+
+### Without Load Balancer (Service Connect only)
+
+```terraform
+module "sc_service" {
+
+}
+```
+
 ## Configuration
 <!-- BEGIN_TF_DOCS -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.89.0 |
+
+### Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_autoscaling_label"></a> [autoscaling\_label](#module\_autoscaling\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_autoscaling_scheduled_label"></a> [autoscaling\_scheduled\_label](#module\_autoscaling\_scheduled\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_autoscaling_target_tracking_label"></a> [autoscaling\_target\_tracking\_label](#module\_autoscaling\_target\_tracking\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_xray_container_definition"></a> [xray\_container\_definition](#module\_xray\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.61.1 |
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [aws_appautoscaling_policy.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy) | resource |
+| [aws_appautoscaling_scheduled_action.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_scheduled_action) | resource |
+| [aws_appautoscaling_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_role_policy.task_ecs_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.execution_ecr_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.execution_ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.task_xray_daemon](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
+| [aws_iam_policy_document.task_ecs_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Whether the service needs a public ip | `bool` | `false` | no |
+| <a name="input_container_definitions"></a> [container\_definitions](#input\_container\_definitions) | List of container definitions, accepts the output of the module https://github.com/cloudposse/terraform-aws-ecs-container-definition | <pre>list(object({<br/>    json_map_encoded                = string<br/>    json_map_encoded_list           = string<br/>    json_map_object                 = any<br/>    sensitive_json_map_encoded      = string<br/>    sensitive_json_map_encoded_list = string<br/>    sensitive_json_map_object       = any<br/>  }))</pre> | n/a | yes |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
+| <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | Desired number of tasks that need to be running for the service | `number` | `1` | no |
+| <a name="input_ecs_cluster_name"></a> [ecs\_cluster\_name](#input\_ecs\_cluster\_name) | Name of the ECS cluster in which the service is deployed | `string` | n/a | yes |
+| <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | Egress rules for the default security group for the service | <pre>list(object({<br/>    description = string<br/>    from_port   = number<br/>    to_port     = number<br/>    protocol    = optional(string, "-1")<br/><br/>    cidr_blocks      = optional(list(string))<br/>    ipv6_cidr_blocks = optional(list(string))<br/>    prefix_list_ids  = optional(list(string))<br/>    security_groups  = optional(list(string))<br/>    self             = optional(bool)<br/>  }))</pre> | `[]` | no |
+| <a name="input_enable_ecs_execute_command"></a> [enable\_ecs\_execute\_command](#input\_enable\_ecs\_execute\_command) | Enables ECS exec to the service and attaches required IAM policy to task role | `bool` | `false` | no |
+| <a name="input_execution_role_arn"></a> [execution\_role\_arn](#input\_execution\_role\_arn) | Arn for the IAM Role used as the execution role | `string` | n/a | yes |
+| <a name="input_force_new_deployment"></a> [force\_new\_deployment](#input\_force\_new\_deployment) | Whether to force a new deployment of the service. This can be used to update the service with a new task definition | `bool` | `false` | no |
+| <a name="input_high_traffic_service"></a> [high\_traffic\_service](#input\_high\_traffic\_service) | Whether the service is a high traffic service: >500 requests/second | `bool` | `false` | no |
+| <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | Ingress rules for the default security group for the service | <pre>list(object({<br/>    description = string<br/>    from_port   = number<br/>    to_port     = number<br/>    protocol    = optional(string, "-1")<br/><br/>    cidr_blocks      = optional(list(string))<br/>    ipv6_cidr_blocks = optional(list(string))<br/>    prefix_list_ids  = optional(list(string))<br/>    security_groups  = optional(list(string))<br/>    self             = optional(bool)<br/>  }))</pre> | `[]` | no |
+| <a name="input_load_balancers"></a> [load\_balancers](#input\_load\_balancers) | List of load balancers to attach to the service | <pre>list(object({<br/>    target_group_arn = string<br/>    container_name   = string<br/>    container_port   = number<br/>  }))</pre> | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the ECS service | `string` | n/a | yes |
+| <a name="input_platform_version"></a> [platform\_version](#input\_platform\_version) | Platform version for the ECS service | `string` | `"LATEST"` | no |
+| <a name="input_scaling"></a> [scaling](#input\_scaling) | Scaling configuration for the service. Enables scaling | <pre>object({<br/>    min_capacity = number<br/>    max_capacity = number<br/>  })</pre> | `null` | no |
+| <a name="input_scaling_scheduled"></a> [scaling\_scheduled](#input\_scaling\_scheduled) | Scheduled scaling policies for the service. Enables Scheduled scaling | <pre>map(object({<br/>    schedule     = string<br/>    timezone     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `null` | no |
+| <a name="input_scaling_target"></a> [scaling\_target](#input\_scaling\_target) | Target tracking scaling policies for the service. Enables Target tracking scaling. Predefined metric type must be one of ECSServiceAverageCPUUtilization, ALBRequestCountPerTarget or ECSServiceAverageMemoryUtilization - https://docs.aws.amazon.com/autoscaling/application/APIReference/API_PredefinedMetricSpecification.html | <pre>map(object({<br/>    predefined_metric_specification = string<br/>    resource_label                  = optional(string)<br/>    target_value                    = number<br/>    scale_in_cooldown               = number<br/>    scale_out_cooldown              = number<br/>  }))</pre> | `null` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of additional security groups to attach to the service | `list(string)` | `[]` | no |
+| <a name="input_service_connect_configuration"></a> [service\_connect\_configuration](#input\_service\_connect\_configuration) | Service discovery configuration for the service | <pre>object({<br/>    namespace      = string<br/>    discovery_name = string<br/>    port_name      = string<br/>    client_alias = object({<br/>      dns_name = string<br/>      port     = number<br/>    })<br/>    cloudwatch = optional(object({<br/>      log_group = string<br/>      region    = string<br/>    }))<br/>  })</pre> | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of Subnet ids in which the Service runs | `list(string)` | n/a | yes |
+| <a name="input_task_cpu"></a> [task\_cpu](#input\_task\_cpu) | value in cpu units for the task | `number` | n/a | yes |
+| <a name="input_task_memory"></a> [task\_memory](#input\_task\_memory) | value in MiB for the task | `number` | n/a | yes |
+| <a name="input_task_role_arn"></a> [task\_role\_arn](#input\_task\_role\_arn) | Arn for the IAM Role used as the task role | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC in which the service is deployed | `string` | n/a | yes |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The ARN of the ECS cluster |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the ECS cluster |
+| <a name="output_label_context"></a> [label\_context](#output\_label\_context) | Context of the label for subsequent use |
+| <a name="output_scaling_target"></a> [scaling\_target](#output\_scaling\_target) | The autoscaling target resource - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target |
+| <a name="output_service_arn"></a> [service\_arn](#output\_service\_arn) | The ARN of the service |
+| <a name="output_service_discovery_client_aliases"></a> [service\_discovery\_client\_aliases](#output\_service\_discovery\_client\_aliases) | The service discovery client aliases for the service |
+| <a name="output_service_discovery_internal_url"></a> [service\_discovery\_internal\_url](#output\_service\_discovery\_internal\_url) | Base URL for the service internally |
+| <a name="output_service_discovery_name"></a> [service\_discovery\_name](#output\_service\_discovery\_name) | The service discovery name for the service |
+| <a name="output_service_id"></a> [service\_id](#output\_service\_id) | The ID of the service |
+| <a name="output_service_name"></a> [service\_name](#output\_service\_name) | The name of the service |
+| <a name="output_task_definition_arn"></a> [task\_definition\_arn](#output\_task\_definition\_arn) | The ARN of the task definition |
+| <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | The family of the task definition |
+| <a name="output_task_definition_id"></a> [task\_definition\_id](#output\_task\_definition\_id) | The ID of the task definition |
 <!-- END_TF_DOCS -->

--- a/ecs-service.tf
+++ b/ecs-service.tf
@@ -1,0 +1,91 @@
+locals {
+  container_names = [for definition in local.container_definitions : definition.sensitive_json_map_object.name]
+
+  container_port_names          = { for definition in local.container_definitions : definition.sensitive_json_map_object.name => definition.sensitive_json_map_object.portMappings[*].containerPort }
+  load_balancer_container_names = length(var.load_balancers) ? [for lb in var.load_balancers : lb.container_name] : []
+}
+
+resource "aws_ecs_service" "this" {
+  name = module.label.id
+
+  cluster          = data.aws_ecs_cluster.this.arn
+  task_definition  = aws_ecs_task_definition.this.arn
+  launch_type      = "FARGATE"
+  platform_version = var.platform_version
+
+  enable_execute_command = var.enable_ecs_execute_command
+
+  desired_count                      = var.desired_count
+  force_new_deployment               = var.force_new_deployment
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 400
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    subnets          = var.subnets
+    security_groups  = concat([aws_security_group.this.id], var.security_group_ids)
+    assign_public_ip = var.assign_public_ip
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = var.service_connect_configuration.namespace
+
+    service {
+      discovery_name = var.service_connect_configuration.discovery_name
+      port_name      = var.service_connect_configuration.port_name
+
+      client_alias {
+        dns_name = var.service_connect_configuration.client_alias.dns_name
+        port     = var.service_connect_configuration.client_alias.port
+      }
+    }
+
+    dynamic "log_configuration" {
+      for_each = var.service_connect_configuration.cloudwatch != null ? [var.service_connect_configuration.cloudwatch] : []
+
+      content {
+        log_driver = "awslogs"
+        options = {
+          "awslogs-group"         = log_configuration.value.log_group
+          "awslogs-region"        = log_configuration.value.region
+          "awslogs-stream-prefix" = "service-connect"
+        }
+      }
+    }
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.load_balancers
+
+    content {
+      target_group_arn = load_balancer.value.target_group_arn
+      container_name   = load_balancer.value.container_name
+      container_port   = load_balancer.value.container_port
+    }
+  }
+
+  tags = module.label.tags
+
+  depends_on = [aws_iam_role_policy_attachment.execution_ecs_task]
+
+  lifecycle {
+    ignore_changes = [desired_count]
+
+    precondition {
+      condition     = contains(local.container_port_names, var.service_connect_configuration.port_name)
+      error_message = "Port name must be one of the container port names"
+    }
+    precondition {
+      condition     = length(local.load_balancer_container_names) == 0 || alltrue([for name in local.load_balancer_container_names : contains(local.container_names, name)])
+      error_message = "Load Balancer container name must be one of the container names"
+    }
+    precondition {
+      condition     = length(local.load_balancer_container_names) == 0 || alltrue([for lb in var.load_balancers : contains(local.container_port_names[lb.container_name], lb.container_port)])
+      error_message = "Load Balancer container port must be one of the container ports"
+    }
+  }
+}

--- a/ecs-task-definition.tf
+++ b/ecs-task-definition.tf
@@ -1,0 +1,53 @@
+locals {
+  container_definitions = concat(var.container_definitions, [module.xray_container_definition])
+
+  container_definitions_encoded = [for definition in local.container_definitions : definition.sensitive_json_map_encoded]
+  container_definitions_list    = "[${join(",", local.container_definitions_encoded)}]"
+
+  required_cpu    = sum([for definition in local.container_definitions : definition.sensitive_json_map_object.cpu]) + (var.high_traffic_service ? 512 : 256)
+  required_memory = sum([for definition in local.container_definitions : definition.sensitive_json_map_object.memory])
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                = module.label.id
+  container_definitions = local.container_definitions_list
+
+  cpu    = var.task_cpu
+  memory = var.task_memory
+
+  task_role_arn      = var.task_role_arn
+  execution_role_arn = var.execution_role_arn
+
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+
+  tags = module.label.tags
+
+  lifecycle {
+    precondition {
+      condition     = var.task_cpu > local.required_cpu
+      error_message = "task_cpu must be greater than or equal to the sum of CPU for all containers in the task definition, including envoy (256 or 512)"
+    }
+
+    precondition {
+      condition     = var.task_memory >= local.required_memory
+      error_message = "value must be greater than or equal to the sum of Memory for all containers in the task definition"
+    }
+    precondition {
+      condition     = contains([256, 512, 1024, 2048, 4096, 8192, 16384], var.task_cpu)
+      error_message = "Task CPU must be one of 256, 512, 1024, 2048, 4096, 8192, 16384"
+    }
+    precondition {
+      condition = (
+        var.task_cpu == 256 && contains([512, 1024, 2048], var.task_memory) ||
+        var.task_cpu == 512 && contains([1024, 2048, 4096], var.task_memory) ||
+        var.task_cpu == 1024 && contains([2048, 3072, 4096, 5120, 6144, 7168, 8192], var.task_memory) ||
+        var.task_cpu == 2048 && contains([4096, 5120, 6144, 7168, 8192, 9216, 10240, 11264, 12288, 13312, 14336, 15360, 16384], var.task_memory) ||
+        var.task_cpu == 4096 && var.task_memory >= 8192 && var.task_memory <= 30720 && var.task_memory % 1024 == 0 ||
+        var.task_cpu == 8192 && var.task_memory >= 16384 && var.task_memory <= 61440 && var.task_memory % 4096 == 0 ||
+        var.task_cpu == 16384 && var.task_memory >= 32768 && var.task_memory <= 122880 && var.task_memory % 8192 == 0
+      )
+      error_message = "must be a valid combination of task_cpu and task_memory - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html#fargate-tasks-size"
+    }
+  }
+}

--- a/iam-role-policies.tf
+++ b/iam-role-policies.tf
@@ -1,0 +1,47 @@
+# ############## #
+# Execution Role #
+# ############## #
+
+resource "aws_iam_role_policy_attachment" "execution_ecr_public" {
+  role = var.execution_role_arn
+
+  policy_arn = "arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "execution_ecs_task" {
+  role = var.execution_role_arn
+
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# ######### #
+# Task Role #
+# ######### #
+
+resource "aws_iam_role_policy_attachment" "task_xray_daemon" {
+  role = var.task_role_arn
+
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+data "aws_iam_policy_document" "task_ecs_exec" {
+  statement {
+    sid    = "ECSExec"
+    effect = "Allow"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "task_ecs_exec" {
+  count = var.enable_ecs_execute_command ? 1 : 0
+
+  name   = join("-", [module.label.id, "ecs-exec"])
+  role   = var.task_role_arn
+  policy = data.aws_iam_policy_document.task_ecs_exec
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,19 @@
+module "label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  context = var.context
+  name    = var.name
+}
+
+# module "path" {
+#   source  = "cloudposse/label/null"
+#   version = "0.25.0"
+
+#   context = module.label.context
+#   delimiter = var.path_delimiter
+# }
+
+data "aws_ecs_cluster" "this" {
+  cluster_name = var.ecs_cluster_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,64 @@
+output "label_context" {
+  value       = module.label.context
+  description = "Context of the label for subsequent use"
+}
+
+output "cluster_name" {
+  value       = data.aws_ecs_cluster.this.cluster_name
+  description = "The name of the ECS cluster"
+}
+
+output "cluster_arn" {
+  value       = data.aws_ecs_cluster.this.arn
+  description = "The ARN of the ECS cluster"
+}
+
+output "task_definition_id" {
+  value       = aws_ecs_task_definition.this.id
+  description = "The ID of the task definition"
+}
+
+output "task_definition_arn" {
+  value       = aws_ecs_task_definition.this.arn
+  description = "The ARN of the task definition"
+}
+
+output "task_definition_family" {
+  value       = aws_ecs_task_definition.this.family
+  description = "The family of the task definition"
+}
+
+output "service_id" {
+  value       = aws_ecs_service.this.id
+  description = "The ID of the service"
+}
+
+output "service_name" {
+  value       = aws_ecs_service.this.name
+  description = "The name of the service"
+}
+
+output "service_arn" {
+  value       = aws_ecs_service.this.id
+  description = "The ARN of the service"
+}
+
+output "scaling_target" {
+  value       = local.scaling_enabled ? aws_appautoscaling_target.this[0] : null
+  description = "The autoscaling target resource - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target"
+}
+
+output "service_discovery_name" {
+  value       = aws_ecs_service.this.service_connect_configuration[0].service[0].discovery_name
+  description = "The service discovery name for the service"
+}
+
+output "service_discovery_client_aliases" {
+  value       = aws_ecs_service.this.service_connect_configuration[0].service[0].client_alias
+  description = "The service discovery client aliases for the service"
+}
+
+output "service_discovery_internal_url" {
+  value       = "http://${aws_ecs_service.this.service_connect_configuration[0].service[0].client_alias[0].dns_name}:${aws_ecs_service.this.service_connect_configuration[0].service[0].client_alias[0].port}"
+  description = "Base URL for the service internally"
+}

--- a/scaling.tf
+++ b/scaling.tf
@@ -1,0 +1,94 @@
+locals {
+  scaling_enabled                 = var.scaling != null
+  scheduled_scaling_enabled       = local.scaling_enabled && var.scaling_scheduled != null
+  target_tracking_scaling_enabled = local.scaling_enabled && var.scaling_target != null
+}
+
+module "autoscaling_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  context    = module.label.context
+  attributes = ["scaling"]
+}
+
+# ############## #
+# Scaling Target #
+# ############## #
+
+resource "aws_appautoscaling_target" "this" {
+  count = local.scaling_enabled ? 1 : 0
+
+  resource_id        = "service/${data.aws_ecs_cluster.this.cluster_name}/${aws_ecs_service.this.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+
+  min_capacity = var.scaling.min_capacity
+  max_capacity = var.scaling.max_capacity
+
+  tags = module.autoscaling_label.tags
+}
+
+# ########################## #
+# Scheduled Scaling Policies #
+# ########################## #
+
+module "autoscaling_scheduled_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  for_each   = local.scheduled_scaling_enabled ? var.scaling_scheduled : {}
+  context    = module.autoscaling_label.context
+  attributes = concat(module.autoscaling_label.attributes, ["scheduled", each.key])
+}
+
+resource "aws_appautoscaling_scheduled_action" "this" {
+  for_each = local.scheduled_scaling_enabled ? var.scaling_scheduled : {}
+
+  name = module.autoscaling_scheduled_label[each.key].id
+
+  resource_id        = aws_appautoscaling_target.this[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.this[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.this[0].service_namespace
+
+  schedule = each.value.schedule
+  timezone = each.value.timezone
+
+  scalable_target_action {
+    min_capacity = each.value.min_capacity
+    max_capacity = each.value.max_capacity
+  }
+}
+
+# ############################## #
+# Target Tracking Scaling Policy #
+# ############################## #
+
+module "autoscaling_target_tracking_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  for_each   = local.target_tracking_scaling_enabled ? var.scaling_target : {}
+  context    = module.autoscaling_label.context
+  attributes = concat(module.autoscaling_label.attributes, [each.key])
+}
+
+resource "aws_appautoscaling_policy" "target" {
+  for_each = local.scaling_enabled ? var.scaling_target : {}
+
+  name               = module.autoscaling_target_tracking_label[each.key].id
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.this[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.this[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.this[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = each.value.predefined_metric_type
+    }
+
+    target_value       = each.value.target_value
+    scale_in_cooldown  = each.value.scale_in_cooldown
+    scale_out_cooldown = each.value.scale_out_cooldown
+  }
+}

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,0 +1,49 @@
+resource "aws_security_group" "this" {
+  name        = module.label.id
+  description = "Security Group for ${module.label.id}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow requestss from within the Security Group"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
+
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+
+    content {
+      description = ingress.value.description
+
+      from_port = ingress.value.from_port
+      to_port   = ingress.value.to_port
+      protocol  = ingress.value.protocol
+
+      cidr_blocks      = ingress.value.cidr_blocks
+      ipv6_cidr_blocks = ingress.value.ipv6_cidr_blocks
+      prefix_list_ids  = ingress.value.prefix_list_ids
+      security_groups  = ingress.value.security_groups
+      self             = ingress.value.self
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.egress_rules
+
+    content {
+      description = egress.value.description
+
+      from_port = egress.value.from_port
+      to_port   = egress.value.to_port
+      protocol  = egress.value.protocol
+
+      cidr_blocks      = egress.value.cidr_blocks
+      ipv6_cidr_blocks = egress.value.ipv6_cidr_blocks
+      prefix_list_ids  = egress.value.prefix_list_ids
+      security_groups  = egress.value.security_groups
+      self             = egress.value.self
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,260 @@
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the ECS service"
+}
+
+
+variable "task_cpu" {
+  type        = number
+  description = "value in cpu units for the task"
+
+  validation {
+    condition     = contains([256, 512, 1024, 2048, 4096, 8192, 16384], var.task_cpu)
+    error_message = "Task CPU must be one of 256, 512, 1024, 2048, 4096, 8192, 16384"
+  }
+}
+
+variable "task_memory" {
+  type        = number
+  description = "value in MiB for the task"
+}
+
+variable "container_definitions" {
+  type = list(object({
+    json_map_encoded                = string
+    json_map_encoded_list           = string
+    json_map_object                 = any
+    sensitive_json_map_encoded      = string
+    sensitive_json_map_encoded_list = string
+    sensitive_json_map_object       = any
+  }))
+  description = "List of container definitions, accepts the output of the module https://github.com/cloudposse/terraform-aws-ecs-container-definition"
+}
+
+variable "task_role_arn" {
+  type        = string
+  description = "Arn for the IAM Role used as the task role"
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::[[:digit:]]{12}:role/.+", var.task_role_arn))
+    error_message = "Must be a valid AWS IAM role ARN."
+  }
+}
+
+variable "execution_role_arn" {
+  type        = string
+  description = "Arn for the IAM Role used as the execution role"
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::[[:digit:]]{12}:role/.+", var.execution_role_arn))
+    error_message = "Must be a valid AWS IAM role ARN."
+  }
+}
+
+variable "enable_ecs_execute_command" {
+  type        = bool
+  description = "Enables ECS exec to the service and attaches required IAM policy to task role"
+  default     = false
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "ID of the VPC in which the service is deployed"
+}
+
+variable "ecs_cluster_name" {
+  type        = string
+  description = "Name of the ECS cluster in which the service is deployed"
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Desired number of tasks that need to be running for the service"
+  default     = 1
+}
+
+variable "subnets" {
+  type        = list(string)
+  description = "List of Subnet ids in which the Service runs"
+}
+
+variable "assign_public_ip" {
+  type        = bool
+  description = "Whether the service needs a public ip"
+  default     = false
+}
+
+variable "high_traffic_service" {
+  type        = bool
+  description = "Whether the service is a high traffic service: >500 requests/second"
+  default     = false
+
+}
+
+variable "service_connect_configuration" {
+  type = object({
+    namespace      = string
+    discovery_name = string
+    port_name      = string
+    client_alias = object({
+      dns_name = string
+      port     = number
+    })
+    cloudwatch = optional(object({
+      log_group = string
+      region    = string
+    }))
+  })
+  description = "Service discovery configuration for the service"
+}
+
+variable "ingress_rules" {
+  type = list(object({
+    description = string
+    from_port   = number
+    to_port     = number
+    protocol    = optional(string, "-1")
+
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    security_groups  = optional(list(string))
+    self             = optional(bool)
+  }))
+  description = "Ingress rules for the default security group for the service"
+  default     = []
+}
+
+variable "egress_rules" {
+  type = list(object({
+    description = string
+    from_port   = number
+    to_port     = number
+    protocol    = optional(string, "-1")
+
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    prefix_list_ids  = optional(list(string))
+    security_groups  = optional(list(string))
+    self             = optional(bool)
+  }))
+  description = "Egress rules for the default security group for the service"
+  default     = []
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "List of additional security groups to attach to the service"
+  default     = []
+}
+
+variable "platform_version" {
+  type        = string
+  description = "Platform version for the ECS service"
+  default     = "LATEST"
+}
+
+variable "force_new_deployment" {
+  type        = bool
+  description = "Whether to force a new deployment of the service. This can be used to update the service with a new task definition"
+  default     = false
+}
+
+variable "load_balancers" {
+  type = list(object({
+    target_group_arn = string
+    container_name   = string
+    container_port   = number
+  }))
+  description = "List of load balancers to attach to the service"
+  default     = []
+}
+
+variable "scaling" {
+  type = object({
+    min_capacity = number
+    max_capacity = number
+  })
+  description = "Scaling configuration for the service. Enables scaling"
+  default     = null
+}
+
+variable "scaling_scheduled" {
+  type = map(object({
+    schedule     = string
+    timezone     = string
+    min_capacity = number
+    max_capacity = number
+  }))
+  description = "Scheduled scaling policies for the service. Enables Scheduled scaling"
+  default     = null
+}
+
+variable "scaling_target" {
+  type = map(object({
+    predefined_metric_specification = string
+    resource_label                  = optional(string)
+    target_value                    = number
+    scale_in_cooldown               = number
+    scale_out_cooldown              = number
+  }))
+  description = "Target tracking scaling policies for the service. Enables Target tracking scaling. Predefined metric type must be one of ECSServiceAverageCPUUtilization, ALBRequestCountPerTarget or ECSServiceAverageMemoryUtilization - https://docs.aws.amazon.com/autoscaling/application/APIReference/API_PredefinedMetricSpecification.html"
+  default     = null
+
+  validation {
+    condition     = var.scaling_target != null && alltrue([for policy in var.scaling_target : contains(["ECSServiceAverageCPUUtilization", "ALBRequestCountPerTarget", "ECSServiceAverageMemoryUtilization"], policy.predefined_metric_specification)])
+    error_message = "Predefined metric type should be one of ECSServiceAverageCPUUtilization or ECSServiceAverageMemoryUtilization"
+  }
+
+  validation {
+    condition     = var.scaling_target != null && alltrue([for policy in var.scaling_target : (policy.predefined_metric_type == "ALBRequestCountPerTarget" && regex("^app/.+/[[:alnum:]]+/targetgroup/.+/[[:alnum:]]+", policy.resource_label)) || true])
+    error_message = "When predefined metric type is ALBRequestCountPerTarget, resource_label must be set and following the format defined on https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PredefinedMetricSpecification.html"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9"
+    }
+  }
+}

--- a/xray-container.tf
+++ b/xray-container.tf
@@ -1,0 +1,21 @@
+module "xray_container_definition" {
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.61.1"
+
+  container_name               = "xray-daemon"
+  container_image              = "amazon/aws-xray-daemon:3.x"
+  container_cpu                = 128
+  container_memory             = 256
+  container_memory_reservation = 128
+  essential                    = true
+  stop_timeout                 = 30
+
+  port_mappings = [
+    {
+      containerPort : 2000,
+      hostPort : 2000,
+      protocol : "udp"
+      name : "xray"
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces the Terraform configuration to create the following resources:
- `aws_ecs_service`
- `aws_ecs_task_definition`
- `aws_security_group`

It attaches the following Policies to the Task Execution role:
- `arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly` for pulling containers from ECR
- `arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy` for being able to run an ECS task

And the following policies to the Task role:
- `arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess` to write traces to XRay
- `ECSExec` when `var.enable_ecs_execute_command` is set to `true`

The following Autoscaling policies can be enabled:
- `scheduled`
- `target tracking scaling`

### Resources

| Name | Type |
|------|------|
| [aws_appautoscaling_policy.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy) | resource |
| [aws_appautoscaling_scheduled_action.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_scheduled_action) | resource |
| [aws_appautoscaling_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
| [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
| [aws_ecs_task_definition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
| [aws_iam_role_policy.task_ecs_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
| [aws_iam_role_policy_attachment.execution_ecr_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
| [aws_iam_role_policy_attachment.execution_ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
| [aws_iam_role_policy_attachment.task_xray_daemon](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
| [aws_iam_policy_document.task_ecs_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

### Inputs

| Name | Description | Type | Default | Required |
|------|-------------|------|---------|:--------:|
| <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Whether the service needs a public ip | `bool` | `false` | no |
| <a name="input_container_definitions"></a> [container\_definitions](#input\_container\_definitions) | List of container definitions, accepts the output of the module https://github.com/cloudposse/terraform-aws-ecs-container-definition | <pre>list(object({<br/>    json_map_encoded                = string<br/>    json_map_encoded_list           = string<br/>    json_map_object                 = any<br/>    sensitive_json_map_encoded      = string<br/>    sensitive_json_map_encoded_list = string<br/>    sensitive_json_map_object       = any<br/>  }))</pre> | n/a | yes |
| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
| <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | Desired number of tasks that need to be running for the service | `number` | `1` | no |
| <a name="input_ecs_cluster_name"></a> [ecs\_cluster\_name](#input\_ecs\_cluster\_name) | Name of the ECS cluster in which the service is deployed | `string` | n/a | yes |
| <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | Egress rules for the default security group for the service | <pre>list(object({<br/>    description = string<br/>    from_port   = number<br/>    to_port     = number<br/>    protocol    = optional(string, "-1")<br/><br/>    cidr_blocks      = optional(list(string))<br/>    ipv6_cidr_blocks = optional(list(string))<br/>    prefix_list_ids  = optional(list(string))<br/>    security_groups  = optional(list(string))<br/>    self             = optional(bool)<br/>  }))</pre> | `[]` | no |
| <a name="input_enable_ecs_execute_command"></a> [enable\_ecs\_execute\_command](#input\_enable\_ecs\_execute\_command) | Enables ECS exec to the service and attaches required IAM policy to task role | `bool` | `false` | no |
| <a name="input_execution_role_arn"></a> [execution\_role\_arn](#input\_execution\_role\_arn) | Arn for the IAM Role used as the execution role | `string` | n/a | yes |
| <a name="input_force_new_deployment"></a> [force\_new\_deployment](#input\_force\_new\_deployment) | Whether to force a new deployment of the service. This can be used to update the service with a new task definition | `bool` | `false` | no |
| <a name="input_high_traffic_service"></a> [high\_traffic\_service](#input\_high\_traffic\_service) | Whether the service is a high traffic service: >500 requests/second | `bool` | `false` | no |
| <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | Ingress rules for the default security group for the service | <pre>list(object({<br/>    description = string<br/>    from_port   = number<br/>    to_port     = number<br/>    protocol    = optional(string, "-1")<br/><br/>    cidr_blocks      = optional(list(string))<br/>    ipv6_cidr_blocks = optional(list(string))<br/>    prefix_list_ids  = optional(list(string))<br/>    security_groups  = optional(list(string))<br/>    self             = optional(bool)<br/>  }))</pre> | `[]` | no |
| <a name="input_load_balancers"></a> [load\_balancers](#input\_load\_balancers) | List of load balancers to attach to the service | <pre>list(object({<br/>    target_group_arn = string<br/>    container_name   = string<br/>    container_port   = number<br/>  }))</pre> | `[]` | no |
| <a name="input_name"></a> [name](#input\_name) | Name of the ECS service | `string` | n/a | yes |
| <a name="input_platform_version"></a> [platform\_version](#input\_platform\_version) | Platform version for the ECS service | `string` | `"LATEST"` | no |
| <a name="input_scaling"></a> [scaling](#input\_scaling) | Scaling configuration for the service. Enables scaling | <pre>object({<br/>    min_capacity = number<br/>    max_capacity = number<br/>  })</pre> | `null` | no |
| <a name="input_scaling_scheduled"></a> [scaling\_scheduled](#input\_scaling\_scheduled) | Scheduled scaling policies for the service. Enables Scheduled scaling | <pre>map(object({<br/>    schedule     = string<br/>    timezone     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `null` | no |
| <a name="input_scaling_target"></a> [scaling\_target](#input\_scaling\_target) | Target tracking scaling policies for the service. Enables Target tracking scaling. Predefined metric type must be one of ECSServiceAverageCPUUtilization, ALBRequestCountPerTarget or ECSServiceAverageMemoryUtilization - https://docs.aws.amazon.com/autoscaling/application/APIReference/API_PredefinedMetricSpecification.html | <pre>map(object({<br/>    predefined_metric_specification = string<br/>    resource_label                  = optional(string)<br/>    target_value                    = number<br/>    scale_in_cooldown               = number<br/>    scale_out_cooldown              = number<br/>  }))</pre> | `null` | no |
| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of additional security groups to attach to the service | `list(string)` | `[]` | no |
| <a name="input_service_connect_configuration"></a> [service\_connect\_configuration](#input\_service\_connect\_configuration) | Service discovery configuration for the service | <pre>object({<br/>    namespace      = string<br/>    discovery_name = string<br/>    port_name      = string<br/>    client_alias = object({<br/>      dns_name = string<br/>      port     = number<br/>    })<br/>    cloudwatch = optional(object({<br/>      log_group = string<br/>      region    = string<br/>    }))<br/>  })</pre> | n/a | yes |
| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of Subnet ids in which the Service runs | `list(string)` | n/a | yes |
| <a name="input_task_cpu"></a> [task\_cpu](#input\_task\_cpu) | value in cpu units for the task | `number` | n/a | yes |
| <a name="input_task_memory"></a> [task\_memory](#input\_task\_memory) | value in MiB for the task | `number` | n/a | yes |
| <a name="input_task_role_arn"></a> [task\_role\_arn](#input\_task\_role\_arn) | Arn for the IAM Role used as the task role | `string` | n/a | yes |
| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC in which the service is deployed | `string` | n/a | yes |

### Outputs

| Name | Description |
|------|-------------|
| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The ARN of the ECS cluster |
| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the ECS cluster |
| <a name="output_label_context"></a> [label\_context](#output\_label\_context) | Context of the label for subsequent use |
| <a name="output_scaling_target"></a> [scaling\_target](#output\_scaling\_target) | The autoscaling target resource - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target |
| <a name="output_service_arn"></a> [service\_arn](#output\_service\_arn) | The ARN of the service |
| <a name="output_service_discovery_client_aliases"></a> [service\_discovery\_client\_aliases](#output\_service\_discovery\_client\_aliases) | The service discovery client aliases for the service |
| <a name="output_service_discovery_internal_url"></a> [service\_discovery\_internal\_url](#output\_service\_discovery\_internal\_url) | Base URL for the service internally |
| <a name="output_service_discovery_name"></a> [service\_discovery\_name](#output\_service\_discovery\_name) | The service discovery name for the service |
| <a name="output_service_id"></a> [service\_id](#output\_service\_id) | The ID of the service |
| <a name="output_service_name"></a> [service\_name](#output\_service\_name) | The name of the service |
| <a name="output_task_definition_arn"></a> [task\_definition\_arn](#output\_task\_definition\_arn) | The ARN of the task definition |
| <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | The family of the task definition |
| <a name="output_task_definition_id"></a> [task\_definition\_id](#output\_task\_definition\_id) | The ID of the task definition |
