### PR TITLE
Whether the XRay container is added is now configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "sc_service" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.93.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.95.0 |
 
 ### Modules
 
@@ -69,6 +69,7 @@ module "sc_service" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_add_xray_container"></a> [add\_xray\_container](#input\_add\_xray\_container) | Whether to add the xray daemon container to the task definition | `bool` | `true` | no |
 | <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Whether the service needs a public ip | `bool` | `false` | no |
 | <a name="input_container_definitions"></a> [container\_definitions](#input\_container\_definitions) | List of container definitions, accepts the inputs of the module https://github.com/cloudposse/terraform-aws-ecs-container-definition | <pre>list(object({<br/>    name              = string<br/>    image             = string<br/>    pull_cache_prefix = optional(string, "")<br/><br/>    cpu                = optional(number)<br/>    memory             = optional(number)<br/>    memory_reservation = optional(number)<br/><br/>    depends_on = optional(list(object({<br/>      condition     = string<br/>      containerName = string<br/>      }))<br/>    )<br/>    essential = optional(bool, true)<br/><br/>    port_mappings = optional(list(object({<br/>      containerPort = number<br/>      protocol      = optional(string, "tcp")<br/>      name          = optional(string)<br/>    })))<br/><br/>    healthcheck = optional(object({<br/>      command     = list(string)<br/>      interval    = optional(number)<br/>      retries     = optional(number)<br/>      startPeriod = optional(number)<br/>      timeout     = optional(number)<br/>    }))<br/>    entrypoint        = optional(list(string))<br/>    command           = optional(list(string))<br/>    working_directory = optional(string)<br/>    environment = optional(list(object({<br/>      name  = string<br/>      value = string<br/>    })))<br/>    secrets = optional(list(object({<br/>      name      = string<br/>      valueFrom = string<br/>    })))<br/>    log_configuration = optional(object({<br/>      logDriver = string<br/>      options   = optional(map(string))<br/>      secretOptions = optional(list(object({<br/>        name      = string<br/>        valueFrom = string<br/>      })))<br/>    }))<br/>    ulimits = optional(list(object({<br/>      hardLimit = number<br/>      name      = string<br/>      softLimit = number<br/>    })))<br/>    user          = optional(string)<br/>    start_timeout = optional(number)<br/>    stop_timeout  = optional(number)<br/>  }))</pre> | n/a | yes |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
@@ -93,6 +94,7 @@ module "sc_service" {
 | <a name="input_task_memory"></a> [task\_memory](#input\_task\_memory) | value in MiB for the task | `number` | n/a | yes |
 | <a name="input_task_role"></a> [task\_role](#input\_task\_role) | IAM Role used as the task role | <pre>object({<br/>    name = string<br/>    arn  = string<br/>  })</pre> | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC in which the service is deployed | `string` | n/a | yes |
+| <a name="input_xray_container_image"></a> [xray\_container\_image](#input\_xray\_container\_image) | The xray daemon container image | `string` | `"amazon/aws-xray-daemon:3.x"` | no |
 
 ### Outputs
 

--- a/container-definitions.tf
+++ b/container-definitions.tf
@@ -1,5 +1,5 @@
 locals {
-  container_definitions = concat(var.container_definitions, [local.xray_container_definition])
+  container_definitions = concat(var.container_definitions, var.add_xray_container ? [local.xray_container_definition] : [])
 }
 
 module "container_definitions" {

--- a/iam-role-policies.tf
+++ b/iam-role-policies.tf
@@ -44,6 +44,8 @@ resource "aws_iam_role_policy" "execution_pull_cache" {
 # ######### #
 
 resource "aws_iam_role_policy_attachment" "task_xray_daemon" {
+  count = var.add_xray_container ? 1 : 0
+
   role = var.task_role.name
 
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"

--- a/variables.tf
+++ b/variables.tf
@@ -309,3 +309,14 @@ variable "scaling_target" {
     error_message = "When predefined metric type is ALBRequestCountPerTarget, resource_label must be set and following the format defined on https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PredefinedMetricSpecification.html"
   }
 }
+
+variable "add_xray_container" {
+  type        = bool
+  description = "Whether to add the xray daemon container to the task definition"
+  default     = true
+}
+variable "xray_container_image" {
+  type        = string
+  description = "The xray daemon container image"
+  default     = "amazon/aws-xray-daemon:3.x"
+}

--- a/xray-container.tf
+++ b/xray-container.tf
@@ -1,7 +1,7 @@
 locals {
   xray_container_definition = {
     name               = "xray-daemon"
-    image              = "amazon/aws-xray-daemon:3.x"
+    image              = var.xray_container_image
     pull_cache_prefix  = ""
     cpu                = 128
     memory             = 256


### PR DESCRIPTION
- Adding the XRay daemon container to the service is configurable

### Resources

_No Resources added_

### Inputs

| Name | Description | Type | Default | Required |
|------|-------------|------|---------|:--------:|
| <a name="input_add_xray_container"></a> [add\_xray\_container](#input\_add\_xray\_container) | Whether to add the xray daemon container to the task definition | `bool` | `true` | no |
| <a name="input_xray_container_image"></a> [xray\_container\_image](#input\_xray\_container\_image) | The xray daemon container image | `string` | `"amazon/aws-xray-daemon:3.x"` | no |

### Outputs

_No outputs added_