### PR TITLE
Update ecr-pull-cache-rule.tf

### DIFF
--- a/ecr-pull-cache-rule.tf
+++ b/ecr-pull-cache-rule.tf
@@ -15,7 +15,7 @@ locals {
     prefix => "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/${rule.ecr_repository_prefix}${endswith(rule.ecr_repository_prefix, "/") ? "" : "/"}"
   }
   pull_cache_rule_arns = { for prefix, rule in data.aws_ecr_pull_through_cache_rule.this :
-    prefix => "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${rule.ecr_repository_prefix}"
+    prefix => "arn:aws:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:repository/${rule.ecr_repository_prefix}"
   }
 }
 


### PR DESCRIPTION
Update deprecated property for `data.aws_region`: `name` => `region`