### PR TITLE
chore(ci): plumb DX_BEARER_TOKEN through the promote-release callee

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -10,6 +10,10 @@ on:
         description: Type of release
         required: true
         type: string
+    secrets:
+      DX_BEARER_TOKEN:
+        required: true
+        description: 'DX bearer token for recording the deployment in getdx.net'
 
 jobs:
   latest-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     with:
       type: latest
       ref: ${{ github.event.release.tag_name }}
+    secrets:
+      DX_BEARER_TOKEN: ${{ secrets.DX_BEARER_TOKEN }}
 
   link-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the two failing observability jobs that have been red on every release since v1.2.2:

| Job | Was failing since | Reason |
|---|---|---|
| `promote_release / latest-release` (DX deployment record) | v1.2.2 | `${{ secrets.DX_BEARER_TOKEN }}` evaluates to \`\"\"\` inside the reusable callee |
| `link-release` (Linear release linking) | v1.2.4 | Same — this repo is public, and the org secrets were scoped to private/internal only |

## Root cause

Two layers stacked together:

1. **Org secret visibility.** `terraform-aws-ecs-service` is a public repo. The three org-level secrets the release workflows depend on (`DX_BEARER_TOKEN`, `LINEAR_API_KEY`, `LINEAR_ACCESS_KEY`) were configured to be available to **Private and internal repositories** only, so this public repo couldn't read them at all. Released runs of v1.2.2 → v1.2.5 all hit this.
2. **Reusable workflow secret plumbing.** `release.yml` calls `promote-release.yml` via `uses:` — a reusable `workflow_call` callee. Reusable workflows do *not* inherit secrets automatically; the caller has to declare them on the call and the callee has to accept them on its `workflow_call.secrets` block. Even once layer 1 is resolved, the callee's `${{ secrets.DX_BEARER_TOKEN }}` reference stays empty without this plumbing.

Layer 1 is being resolved operationally — the org secrets are now scoped to **All repositories**. With that change, the direct `link-release` job in `release.yml` resolves \`LINEAR_API_KEY\` straight from the surrounding workflow context, **no code change needed there**.

This PR addresses layer 2 for `DX_BEARER_TOKEN`, since the DX step lives inside the `workflow_call` callee.

## The fix

Two YAML edits, six new lines total.

`release.yml` — pass the secret to the callee:

```yaml
promote_release:
  uses: ./.github/workflows/promote-release.yml
  with:
    type: latest
    ref: ${{ github.event.release.tag_name }}
  secrets:
    DX_BEARER_TOKEN: ${{ secrets.DX_BEARER_TOKEN }}
```

`promote-release.yml` — accept the secret on `workflow_call`:

```yaml
on:
  workflow_call:
    inputs:
      ref: { ... }
      type: { ... }
    secrets:
      DX_BEARER_TOKEN:
        required: true
        description: 'DX bearer token for recording the deployment in getdx.net'
```

Named-secret passing (rather than `secrets: inherit`) matches the convention used by cVitals-API's release flow for its `DOCKER_*` and `OCTOPUS_*` secrets — explicit beats implicit, and the reusable workflow's secret contract is now visible in the file.

## What stays the same

* `promote_release / create-tags` was always green — it only uses the built-in `GITHUB_TOKEN`. Tagging continues to work either way; this is purely about restoring the two observability sidecars.
* Consumer-facing semantics are unchanged — the floating `latest`, major, and minor tags still get pushed, and the GitHub Release is still created (it's what triggers the workflow).

## Test plan

* [x] `pre-commit run --files .github/workflows/release.yml .github/workflows/promote-release.yml` — all hooks pass, including `Validate GitHub Workflows` schema check.
* [x] Pull-request CI green.
* [ ] On merge: next release should produce three green jobs (`create-tags`, `latest-release`, `link-release`) instead of one-out-of-three.

## Out of scope

* The same pattern likely affects other public Luscii Terraform module repos with the same release wiring. Per discussion, this PR addresses `terraform-aws-ecs-service` only. A follow-up sweep can apply the same fix to siblings if it matters.