### PR TITLE
fix: emit s3files:Client* on access point ARN for s3files volumes

### DIFF
--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -251,10 +251,8 @@ What the module grants:
 | `efs` with `iam = true`, read-only | `elasticfilesystem:ClientMount` | `arn:aws:elasticfilesystem:<region>:<account>:file-system/<file_system_id>` | `StringEquals` on `elasticfilesystem:AccessPointArn` when `access_point_id` is set |
 | `efs` with `iam = true`, RW, with access point | `ClientMount`, `ClientWrite` | file-system ARN | `AccessPointArn` condition (access point already roots the scope, so `ClientRootAccess` is omitted) |
 | `efs` with `iam = true`, RW, no access point | `ClientMount`, `ClientWrite`, `ClientRootAccess` | file-system ARN | — |
-| `s3files`, read-only | `s3:ListBucket` | the `access_point_arn` | — |
-| `s3files`, read-only | `s3:GetObject` | `${access_point_arn}/object/*` | — |
-| `s3files`, RW | `s3:ListBucket` | the `access_point_arn` | — |
-| `s3files`, RW | `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject` | `${access_point_arn}/object/*` | — |
+| `s3files`, read-only | `s3files:ClientMount` | the `access_point_arn` | — |
+| `s3files`, RW | `s3files:ClientMount`, `s3files:ClientWrite` | the `access_point_arn` | — |
 | Any with `kms_key_arn` set, read-only | `kms:Decrypt` | the `kms_key_arn` | — |
 | Any with `kms_key_arn` set, RW | `kms:Decrypt`, `kms:Encrypt`, `kms:GenerateDataKey` | the `kms_key_arn` | — |
 

--- a/iam-role-task.tf
+++ b/iam-role-task.tf
@@ -109,34 +109,28 @@ locals {
     if v.type == "efs" && try(v.efs.authorization_config.iam, false)
   ]
 
-  # S3 Files statement specs. Two per s3files volume — the bucket-level
-  # `s3:ListBucket` and the object-level `s3:GetObject`/`PutObject`/
-  # `DeleteObject` — because the two action sets need different
-  # resource ARNs. AWS access points scope bucket-level actions to the
-  # access point ARN itself, but object-level actions require the
-  # `<access-point-arn>/object/*` form. Granting `s3:GetObject` on the
-  # bare access point ARN silently grants nothing at runtime.
+  # S3 Files statement specs. One per s3files volume — the
+  # `s3files:Client*` mount-auth actions on the access point ARN.
+  # Structurally a sibling of `volume_efs_statements`: single statement,
+  # file-system-level resource (no object-level sub-resource).
+  #
+  # The action set mirrors the AWS-managed
+  # `AmazonS3FilesClientReadWriteAccess` policy
+  # (`ClientMount` + `ClientWrite`); the resource is tighter (the
+  # access point ARN, not `*`).
   # See the `attach` note on `volume_efs_statements`.
-  volume_s3files_statements = flatten([
-    for name, v in var.volumes : [
-      {
-        sid       = "S3FilesList${replace(name, "/[^A-Za-z0-9]/", "")}${substr(sha1(name), 0, 8)}"
-        actions   = ["s3:ListBucket"]
-        resources = [v.s3files.access_point_arn]
-        attach    = v.attach_iam_policy
-      },
-      {
-        sid = "S3FilesObjects${replace(name, "/[^A-Za-z0-9]/", "")}${substr(sha1(name), 0, 8)}"
-        actions = concat(
-          ["s3:GetObject"],
-          local.volume_is_rw[name] ? ["s3:PutObject", "s3:DeleteObject"] : [],
-        )
-        resources = ["${v.s3files.access_point_arn}/object/*"]
-        attach    = v.attach_iam_policy
-      }
-    ]
+  volume_s3files_statements = [
+    for name, v in var.volumes : {
+      sid = "S3FilesClient${replace(name, "/[^A-Za-z0-9]/", "")}${substr(sha1(name), 0, 8)}"
+      actions = concat(
+        ["s3files:ClientMount"],
+        local.volume_is_rw[name] ? ["s3files:ClientWrite"] : [],
+      )
+      resources = [v.s3files.access_point_arn]
+      attach    = v.attach_iam_policy
+    }
     if v.type == "s3files"
-  ])
+  ]
 
   # KMS keys grouped by ARN with the per-key RW signal aggregated
   # across volumes that reference them. Two parallel maps:

--- a/skill/references/volumes.md
+++ b/skill/references/volumes.md
@@ -185,10 +185,8 @@ when at least one volume contributes statements, omitted otherwise.
 | `efs`, `iam = true`, RO | `elasticfilesystem:ClientMount` | file-system ARN | `AccessPointArn` when set |
 | `efs`, `iam = true`, RW, with access point | `+ClientWrite` | file-system ARN | `AccessPointArn` |
 | `efs`, `iam = true`, RW, no access point | `+ClientWrite`, `+ClientRootAccess` | file-system ARN | — |
-| `s3files`, RO | `s3:ListBucket` | access point ARN | — |
-| `s3files`, RO | `s3:GetObject` | `${access_point_arn}/object/*` | — |
-| `s3files`, RW | `s3:ListBucket` | access point ARN | — |
-| `s3files`, RW | `s3:GetObject`, `+s3:PutObject`, `+s3:DeleteObject` | `${access_point_arn}/object/*` | — |
+| `s3files`, RO | `s3files:ClientMount` | access point ARN | — |
+| `s3files`, RW | `s3files:ClientMount`, `+s3files:ClientWrite` | access point ARN | — |
 | Any with `kms_key_arn`, RO | `kms:Decrypt` | KMS key ARN | — |
 | Any with `kms_key_arn`, RW | `+kms:Encrypt`, `+kms:GenerateDataKey` | KMS key ARN | — |
 


### PR DESCRIPTION
## Summary

- **Bug:** v1.2.6's auto-attach for `s3files` volumes emitted `s3:ListBucket` + `s3:GetObject`/`PutObject`/`DeleteObject` on an `arn:aws:s3files:...` access-point ARN. Action service prefix (`s3:`) ≠ resource service namespace (`s3files:`), so AWS evaluates each statement to "no grant" at runtime. `plan`/`apply` succeed; mount fails with `AccessDenied`.
- **Fix:** Replace with the `s3files:Client*` shape, mirroring the existing EFS block — one statement per volume, file-system-level resource (no `/object/*` split), actions matching the AWS-managed `AmazonS3FilesClientReadWriteAccess` policy. Resource is tighter than the managed policy (the access point ARN, not `*`).
- **Closes** [PLA-619](https://linear.app/luscii/issue/PLA-619).

## What changed

| File | Change |
|---|---|
| `iam-role-task.tf` | `volume_s3files_statements` rewritten: 1 statement per volume (was 2), `s3files:ClientMount` (RO) + `s3files:ClientWrite` (RW), `resources = [v.s3files.access_point_arn]`, `flatten()` dropped. |
| `docs/volumes.md` | IAM grant matrix: 4 s3files rows → 2 rows reflecting the new shape. |
| `skill/references/volumes.md` | Same matrix update. |

## How this is verified

- AWS-managed policy [`AmazonS3FilesClientReadWriteAccess`](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html) was inspected directly via `aws iam get-policy-version` — confirms the canonical action set is exactly `s3files:ClientMount` + `s3files:ClientWrite` on `Resource: "*"`. No `DescribeFileSystems`, no `ClientRootAccess`.
- `terraform test` — all 18 cases pass (the `s3files_volume_renders_block_and_policy` assertion on `length(aws_iam_role_policy.task_volumes) == 1` still holds; mocked provider can't inspect JSON content, so the structural assertion is what's available).
- The mesh-client playground (`PLA-550`) currently works around the bug via `attach_iam_policy = false` + manual attachment of `AmazonS3FilesClientReadWriteAccess` — that's the empirical proof the `s3files:Client*` action set is what mounts actually need.

## Follow-up (not in this PR)

After this lands and v1.2.7 is tagged, a small consumer-side PR on `mesh-client` flips `attach_iam_policy = true` (the default) on the playground volume and drops the manual `aws_iam_role_policy_attachment.playground_s3files_client`. PLA-619 acceptance criteria pin that confirmation.

## Test plan

- [x] `terraform test` — 18/18 pass
- [x] Pre-commit hooks pass (fmt, validate, docs, tflint, checkov)
- [ ] `terraform plan` on a scratch consumer with a single s3files volume — confirm inline policy renders `s3files:Client*` on the access point ARN, no `s3:*` (reviewer or me, post-merge sanity)
- [ ] After v1.2.7 tag: mesh-client playground flip-back PR proves auto-attach mounts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)