### PR TITLE
upgrade security group to use rule resources

### DIFF
--- a/security-group.tf
+++ b/security-group.tf
@@ -10,39 +10,37 @@ resource "aws_security_group" "this" {
   tags = module.label.tags
 }
 
-resource "aws_security_group_ingress_rule" "self" {
-  security_group_id = aws_security_group.this.id
-  description       = "Allow requests from within the Security Group"
-  ip_protocol       = "-1"
-  self              = true
+resource "aws_vpc_security_group_ingress_rule" "self" {
+  security_group_id            = aws_security_group.this.id
+  description                  = "Allow requests from within the Security Group"
+  ip_protocol                  = "-1"
+  referenced_security_group_id = aws_security_group.this.id
 }
 
-resource "aws_security_group_ingress_rule" "ingress" {
-  for_each = var.ingress_rules
+resource "aws_vpc_security_group_ingress_rule" "ingress" {
+  for_each = { for idx, rule in var.ingress_rules : idx => rule }
 
-  security_group_id = aws_security_group.this.id
-  description       = each.value.description
-  ip_protocol       = each.value.ip_protocol
-  from_port         = each.value.from_port
-  to_port           = each.value.to_port
-  cidr_blocks       = each.value.cidr_blocks
-  ipv6_cidr_blocks  = each.value.ipv6_cidr_blocks
-  prefix_list_ids   = each.value.prefix_list_ids
-  security_groups   = each.value.security_groups
-  self              = each.value.self
+  security_group_id            = aws_security_group.this.id
+  description                  = each.value.description
+  ip_protocol                  = each.value.protocol
+  from_port                    = each.value.from_port
+  to_port                      = each.value.to_port
+  cidr_ipv4                    = each.value.cidr_blocks == null ? null : one(each.value.cidr_blocks)
+  cidr_ipv6                    = each.value.ipv6_cidr_blocks == null ? null : one(each.value.ipv6_cidr_blocks)
+  prefix_list_id               = each.value.prefix_list_ids == null ? null : one(each.value.prefix_list_ids)
+  referenced_security_group_id = each.value.security_groups == null ? null : one(each.value.security_groups)
 }
 
-resource "aws_security_group_egress_rule" "egress" {
-  for_each = var.egress_rules
+resource "aws_vpc_security_group_egress_rule" "egress" {
+  for_each = { for idx, rule in var.egress_rules : idx => rule }
 
-  security_group_id = aws_security_group.this.id
-  description       = each.value.description
-  ip_protocol       = each.value.ip_protocol
-  from_port         = each.value.from_port
-  to_port           = each.value.to_port
-  cidr_blocks       = each.value.cidr_blocks
-  ipv6_cidr_blocks  = each.value.ipv6_cidr_blocks
-  prefix_list_ids   = each.value.prefix_list_ids
-  security_groups   = each.value.security_groups
-  self              = each.value.self
+  security_group_id            = aws_security_group.this.id
+  description                  = each.value.description
+  ip_protocol                  = each.value.protocol
+  from_port                    = each.value.from_port
+  to_port                      = each.value.to_port
+  cidr_ipv4                    = each.value.cidr_blocks == null ? null : one(each.value.cidr_blocks)
+  cidr_ipv6                    = each.value.ipv6_cidr_blocks == null ? null : one(each.value.ipv6_cidr_blocks)
+  prefix_list_id               = each.value.prefix_list_ids == null ? null : one(each.value.prefix_list_ids)
+  referenced_security_group_id = each.value.security_groups == null ? null : one(each.value.security_groups)
 }

--- a/security-group.tf
+++ b/security-group.tf
@@ -3,49 +3,46 @@ resource "aws_security_group" "this" {
   description = "Security Group for ${module.label.id}"
   vpc_id      = var.vpc_id
 
-  ingress {
-    description = "Allow requests from within the Security Group"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    self        = true
-  }
-
-  dynamic "ingress" {
-    for_each = var.ingress_rules
-
-    content {
-      description = ingress.value.description
-
-      from_port = ingress.value.from_port
-      to_port   = ingress.value.to_port
-      protocol  = ingress.value.protocol
-
-      cidr_blocks      = ingress.value.cidr_blocks
-      ipv6_cidr_blocks = ingress.value.ipv6_cidr_blocks
-      prefix_list_ids  = ingress.value.prefix_list_ids
-      security_groups  = ingress.value.security_groups
-      self             = ingress.value.self
-    }
-  }
-
-  dynamic "egress" {
-    for_each = var.egress_rules
-
-    content {
-      description = egress.value.description
-
-      from_port = egress.value.from_port
-      to_port   = egress.value.to_port
-      protocol  = egress.value.protocol
-
-      cidr_blocks      = egress.value.cidr_blocks
-      ipv6_cidr_blocks = egress.value.ipv6_cidr_blocks
-      prefix_list_ids  = egress.value.prefix_list_ids
-      security_groups  = egress.value.security_groups
-      self             = egress.value.self
-    }
+  lifecycle {
+    create_before_destroy = true
   }
 
   tags = module.label.tags
+}
+
+resource "aws_security_group_ingress_rule" "self" {
+  security_group_id = aws_security_group.this.id
+  description       = "Allow requests from within the Security Group"
+  ip_protocol       = "-1"
+  self              = true
+}
+
+resource "aws_security_group_ingress_rule" "ingress" {
+  for_each = var.ingress_rules
+
+  security_group_id = aws_security_group.this.id
+  description       = each.value.description
+  ip_protocol       = each.value.ip_protocol
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  cidr_blocks       = each.value.cidr_blocks
+  ipv6_cidr_blocks  = each.value.ipv6_cidr_blocks
+  prefix_list_ids   = each.value.prefix_list_ids
+  security_groups   = each.value.security_groups
+  self              = each.value.self
+}
+
+resource "aws_security_group_egress_rule" "egress" {
+  for_each = var.egress_rules
+
+  security_group_id = aws_security_group.this.id
+  description       = each.value.description
+  ip_protocol       = each.value.ip_protocol
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  cidr_blocks       = each.value.cidr_blocks
+  ipv6_cidr_blocks  = each.value.ipv6_cidr_blocks
+  prefix_list_ids   = each.value.prefix_list_ids
+  security_groups   = each.value.security_groups
+  self              = each.value.self
 }

--- a/variables.tf
+++ b/variables.tf
@@ -372,7 +372,7 @@ variable "ingress_rules" {
     security_groups  = optional(list(string))
     self             = optional(bool)
   }))
-  description = "Ingress rules for the default security group for the service"
+  description = " Deprecated: Use aws_security_group_ingress_rule instead. Ingress rules for the default security group for the service."
   default     = []
 }
 
@@ -389,7 +389,7 @@ variable "egress_rules" {
     security_groups  = optional(list(string))
     self             = optional(bool)
   }))
-  description = "Egress rules for the default security group for the service"
+  description = "Deprecated: Use aws_security_group_egress_rule instead. Egress rules for the default security group for the service."
   default     = []
 }
 


### PR DESCRIPTION
## Summary
Migrates the module’s default ECS security group from inline ingress / egress blocks on aws_security_group to standalone rule resources. The security group resource now only defines the group (name, VPC, tags); rules are managed separately.

This fixes the add/destroy flip-flop when consumers attach their own egress/ingress rules (e.g. `aws_vpc_security_group_egress_rule.service_to_db`) to `module.*.security_group_id`. Inline rule management and external standalone rules both claim ownership of the same rules, which causes alternating creates and deletes on every apply.

## Changes:

- Remove all inline ingress / egress blocks from aws_security_group.this
- Add `aws_security_group_ingress_rule.self` for the default self-referencing allow-all rule
- Add `aws_security_group_ingress_rule.ingress `and `aws_security_group_egress_rule.egress` driven by `var.ingress_rules` / `var.egress_rules`
- Add lifecycle { create_before_destroy = true } on the security group
- Mark ingress_rules and egress_rules as deprecated in favor of attaching aws_security_group_*_rule resources directly to security_group_id

## Unchanged for consumers:

- `security_group_id` / `security_group_arn` outputs
- `ngress_rules` / `egress_rules` input shape (still supported for now)