### PR TITLE
Use official Linear release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,15 @@ jobs:
   link-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Link release to Linear tasks
-        uses: Luscii/gha-release-linker@1
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          version-name: ${{ github.event.release.tag_name }}
-          linear-api-key: ${{ secrets.LINEAR_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-mode: both
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+      - name: Create Linear release
+        uses: linear/linear-release-action@e01367f7b3c3a18868a4aab21ea6fdae80430050 # v0.14.2
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          name: ${{ github.event.repository.name }} (${{ github.event.release.tag_name }})
+          version: ${{ github.event.release.tag_name }}
+          links: ${{ github.event.release.html_url }}


### PR DESCRIPTION
Replaces the `Luscii/gha-release-linker` action with the official `linear/linear-release-action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)